### PR TITLE
Listen specifically on 127.0.0.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,5 +52,5 @@ func run(config string) error {
 	http.HandleFunc("/", proxy.ServeHTTP)
 
 	log.Printf("Starting server at port %d and forwarding to %s", port, targetUrl)
-	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+	return http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), nil)
 }


### PR DESCRIPTION
as @gerhard said:

> As a related side note, I think that we should bind tls-exterminator to 127.0.0.1 by default